### PR TITLE
Use generics

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare module update {
   type ObjectSpec = ObjectCommand | SpecPath;
 }
 
-declare function update(value:any[], spec: update.ArrayCommand): any[];
-declare function update(value:{}, spec: update.ObjectSpec): {};
+declare function update<T>(value:T[], spec: update.ArrayCommand): T[];
+declare function update<T>(value:T, spec: update.ObjectSpec): T;
 
 export = update;


### PR DESCRIPTION
Right now `update` will return either `any[]` or `{}` as the type of result regardless of what was passed to it. This update preserves original types passed to function.
